### PR TITLE
forgot the scans job id for output

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,6 +78,7 @@ jobs:
         echo ${{ matrix.ref }}
 
     - uses: distroless/actions/vul-scans@main
+      id: scans
       with:
         registry: ghcr.io
         username: ${{ github.actor }}


### PR DESCRIPTION
The output and alerts ref the scans job, but it can't if it doesn't have the id 

Signed-off-by: James Strong <strong.james.e@gmail.com>