### PR TITLE
update export repo name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,11 +131,11 @@ jobs:
     permissions:
       id-token: write # Enable OIDC
       contents: write
-    env:
-      REPO_NAME: ${{ github.event.repository.name }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
+      - name: Get repository name
+        run: echo "REPO_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
       - name: Generate README
         uses: distroless/readme-generator@main
         with:


### PR DESCRIPTION
the variable `${{ github.event.repository.name }}` is not available in the schedule trigger, and in this way, we make sure we always get the repo name no matter the event trigger